### PR TITLE
#3 Clean up shiro state before start

### DIFF
--- a/src/main/java/com/github/sdorra/shiro/ShiroRule.java
+++ b/src/main/java/com/github/sdorra/shiro/ShiroRule.java
@@ -61,6 +61,8 @@ public class ShiroRule implements MethodRule
   public Statement apply(final Statement base, FrameworkMethod method,
     Object target)
   {
+    tearDownShiro(); // clean up whatever other tests might have left behind
+
     final SubjectAwareDescriptor desc = new SubjectAwareDescriptor();
     SubjectAware subjectAware = SubjectAwares.find(target);
 


### PR DESCRIPTION
There might be some debris left behind from other tests that did not
care to clean up. This should be taken into account before running new
tests.